### PR TITLE
Fix issue installing on aarch64/arm64 platforms

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -10,7 +10,14 @@ HELM_EDIT_VERSION=${HELM_EDIT_VERSION:-"${DEFAULT_VERSION}"}
 
 file="${HELM_PLUGIN_DIR:-"$(helm home)/plugins/helm-edit"}/helm-edit"
 os=$(uname -s | tr '[:upper:]' '[:lower:]')
-url="https://github.com/mstrzele/helm-edit/releases/download/v${HELM_EDIT_VERSION}/helm-edit_${os}_amd64"
+
+if [[ "$(uname -m)" == "aarch64" -o "$(uname -m)" == "arm64" ]]; then
+  arch=arm64
+else
+  arch=amd64
+fi
+
+url="https://github.com/mstrzele/helm-edit/releases/download/v${HELM_EDIT_VERSION}/helm-edit_${os}_${arch}"
 
 if command -v wget; then
   wget -O "${file}"  "${url}"


### PR DESCRIPTION
amd64 is hardcoded as the architecture, which means this won't work on M1 macs, Raspberry Pis, etc.